### PR TITLE
add largeOK = TRUE to RefFreeCellMix_wrapper.R

### DIFF
--- a/R/GetCorRes.R
+++ b/R/GetCorRes.R
@@ -1,4 +1,4 @@
-GetCorRes <- function(selProf, knowRefAll) {
+GetCorRes <- function(selProf, knowRefAll, threshold = 0.55) {
 
      ### implement correlation-based assignment
      isc = intersect(rownames(selProf),rownames(knowRefAll))
@@ -13,10 +13,13 @@ GetCorRes <- function(selProf, knowRefAll) {
      summat_org <- summat
      assignLabel <- rep("Unassigned", ncol(selProf))
      for(i in 1:ncol(knowRefAll)) {
-          thisidx <- which(summat == max(summat), arr.ind = TRUE)
-          assignLabel[thisidx[2]] <- rownames(summat)[thisidx[1]]
-          summat[thisidx[1],] <- -1
-          summat[,thisidx[2]] <- -1 ## I add this
+             if (max(summat) > threshold) {
+                     thisidx <- which(summat == max(summat), arr.ind = TRUE)
+                     assignLabel[thisidx[2]] <- rownames(summat)[thisidx[1]]
+                     summat[thisidx[1],] <- -1
+                     summat[,thisidx[2]] <- -1 ## I add this
+             }
+          
      }
      return(list(assignLabel = assignLabel,
                  probMat = summat_org))

--- a/R/GetCorRes.R
+++ b/R/GetCorRes.R
@@ -12,15 +12,21 @@ GetCorRes <- function(selProf, knowRefAll, threshold = 0.55) {
      summat <- (cormat + nbmat)/2
      summat_org <- summat
      assignLabel <- rep("Unassigned", ncol(selProf))
+     maxSummat <- rep(0, ncol(selProf))
      for(i in 1:ncol(knowRefAll)) {
              if (max(summat) > threshold) {
                      thisidx <- which(summat == max(summat), arr.ind = TRUE)
+                     maxSummat[thisidx[2]] <- max(summat)
                      assignLabel[thisidx[2]] <- rownames(summat)[thisidx[1]]
                      summat[thisidx[1],] <- -1
                      summat[,thisidx[2]] <- -1 ## I add this
+             } else {
+                     thisidx <- which(summat == max(summat), arr.ind = TRUE)
+                     maxSummat[thisidx[2]] <- max(summat)
              }
           
      }
      return(list(assignLabel = assignLabel,
-                 probMat = summat_org))
+                 probMat = summat_org,
+                 scoreAssign = maxSummat))
 }

--- a/R/RefFreeCellMix_wrapper.R
+++ b/R/RefFreeCellMix_wrapper.R
@@ -13,7 +13,8 @@ RefFreeCellMix_wrapper <- function(Y, K) {
     }
     outY <- RefFreeEWAS::RefFreeCellMix(Y,
            mu0=RefFreeEWAS::RefFreeCellMixInitialize(Y,
-                                                     K = K))
+                                                     K = K, 
+                                                     largeOK = TRUE))
     Prop0 <- outY$Omega
     return(Prop0)
 }

--- a/R/Tsisal.R
+++ b/R/Tsisal.R
@@ -1,5 +1,5 @@
 Tsisal <- function(Y_raw, K = NULL, knowRef = NULL,
-                   possibleCellNumber = 3:15){
+                   possibleCellNumber = 3:15, assignThres = 0.55){
 
      # Y_raw is the DNA methylation 450K array data from complex tissues,
      # rows for CpG sites and columns for samples.
@@ -28,7 +28,7 @@ Tsisal <- function(Y_raw, K = NULL, knowRef = NULL,
           prof <- t(out_all$ghat)
           rownames(prof) <- rownames(Y_raw)
           selProf <- prof[unlist(selMarker),]
-          labres <- GetCorRes(selProf, knowRefAll = knowRef)
+          labres <- GetCorRes(selProf, knowRefAll = knowRef, threshold = assignThres)
           colnames(estProp) <- labres$assignLabel
      }
 

--- a/R/Tsisal.R
+++ b/R/Tsisal.R
@@ -30,9 +30,17 @@ Tsisal <- function(Y_raw, K = NULL, knowRef = NULL,
           selProf <- prof[unlist(selMarker),]
           labres <- GetCorRes(selProf, knowRefAll = knowRef, threshold = assignThres)
           colnames(estProp) <- labres$assignLabel
+          scoreLabels <- labres$scoreAssign
+          return(list(estProp = estProp,
+                      selMarker = selMarker,
+                      K = K,
+                      scoreLabels = scoreLabels))
+          
+     } else {
+             return(list(estProp = estProp,
+                         selMarker = selMarker,
+                         K = K)) 
      }
 
-     return(list(estProp = estProp,
-                 selMarker = selMarker,
-                 K = K))
+     
 }


### PR DESCRIPTION
I ran into an issue where I tried to deconvolute over 3000 samples with `Tsisal()`, which is above the 2500 limit of the `RefFreeCellMixInitialize` function called from inside the `RefFreeCellMix_wrapper`. Since there is no way to abolish this limit from inside `TOAST`, I would propose including the `largeOK = TRUE` parameter in the wrapper.